### PR TITLE
Vim-Plugin.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: tpope
+custom: ["https://www.paypal.me/vimpope"]

--- a/README.markdown
+++ b/README.markdown
@@ -33,7 +33,7 @@ installing [pathogen.vim](https://github.com/tpope/vim-pathogen), and
 then simply copy and paste:
 
     cd ~/.vim/bundle
-    git clone git://github.com/tpope/vim-obsession.git
+    git clone https://github.com/tpope/vim-obsession.git
     vim -u NONE -c "helptags vim-obsession/doc" -c q
 
 ## Self-Promotion

--- a/doc/obsession.txt
+++ b/doc/obsession.txt
@@ -12,6 +12,10 @@ USAGE                                           *obsession* *:Obsession*
                         it will be overwritten if and only if it looks like a
                         session file.
 
+                        Set `g:obsession_no_bufenter` to disable saving the
+                        session on |BufEnter|, improving performance at the
+                        expense of safety.
+
 :Obsession {dir}        Invoke |:Obsession| on {dir}/Session.vim.  Use "." to
                         write to a session file in the current directory.
 

--- a/doc/obsession.txt
+++ b/doc/obsession.txt
@@ -33,7 +33,8 @@ STATUS INDICATOR                                *obsession-status*
                                                 *ObsessionStatus()*
 Add %{ObsessionStatus()} to 'statusline', 'tabline', or 'titlestring' to get
 an indicator when Obsession is active or paused.  Pass an argument to override
-the text of the indicator and a second argument to override the text of the
-paused indictor.
+the text of the active indicator and a second argument to override the text of
+the paused indictor.  By default, the active indicator is `[$]`, and the
+paused indicator is `[S]`.
 
  vim:tw=78:et:ft=help:norl:

--- a/plugin/obsession.vim
+++ b/plugin/obsession.vim
@@ -68,9 +68,9 @@ function! s:persist() abort
   endif
   let sessionoptions = &sessionoptions
   if exists('g:this_obsession')
+    let tmp = g:this_obsession . '.' . getpid() . '.obsession~'
     try
       set sessionoptions-=blank sessionoptions-=options sessionoptions+=tabpages
-      let tmp = g:this_obsession . '.obsession.' . getpid()
       exe s:doautocmd_user('ObsessionPre')
       execute 'mksession!' fnameescape(tmp)
       let body = readfile(tmp)

--- a/plugin/obsession.vim
+++ b/plugin/obsession.vim
@@ -54,6 +54,18 @@ function! s:dispatch(bang, file) abort
   endtry
 endfunction
 
+function! s:doautocmd_user(arg) abort
+  if !exists('#User#' . a:arg)
+    return ''
+  elseif v:version >= 704 && 0
+    return 'doautocmd <nomodeline> User ' . fnameescape(a:arg)
+  else
+    return 'try | let [save_mls, &mls] = [&mls, 0] | ' .
+          \ 'doautocmd <nomodeline> User ' . fnameescape(a:arg) . ' | ' .
+          \ 'finally | let &mls = save_mls | endtry'
+  endif
+endfunction
+
 function! s:persist() abort
   if exists('g:SessionLoad')
     return ''
@@ -74,14 +86,7 @@ function! s:persist() abort
       endif
       call writefile(body, g:this_obsession)
       let g:this_session = g:this_obsession
-      if exists('#User#Obsession')
-        try
-          let [save_mls, &modelines] = [&mls, 0]
-          doautocmd User Obsession
-        finally
-          let &mls = save_mls
-        endtry
-      endif
+      exe s:doautocmd_user('Obsession')
     catch
       unlet g:this_obsession
       let &l:readonly = &l:readonly

--- a/plugin/obsession.vim
+++ b/plugin/obsession.vim
@@ -73,6 +73,7 @@ function! s:persist() abort
       set sessionoptions-=blank sessionoptions-=options sessionoptions+=tabpages
       exe s:doautocmd_user('ObsessionPre')
       execute 'mksession!' fnameescape(tmp)
+      let v:this_session = g:this_obsession
       let body = readfile(tmp)
       call insert(body, 'let g:this_session = v:this_session', -3)
       call insert(body, 'let g:this_obsession = v:this_session', -3)

--- a/plugin/obsession.vim
+++ b/plugin/obsession.vim
@@ -78,7 +78,6 @@ function! s:persist() abort
       let body = readfile(g:this_obsession)
       call insert(body, 'let g:this_session = v:this_session', -3)
       call insert(body, 'let g:this_obsession = v:this_session', -3)
-      call insert(body, 'let g:this_obsession_status = 2', -3)
       if type(get(g:, 'obsession_append')) == type([])
         for line in g:obsession_append
           call insert(body, line, -3)

--- a/plugin/obsession.vim
+++ b/plugin/obsession.vim
@@ -68,6 +68,14 @@ function! s:persist() abort
       call insert(body, 'let g:this_obsession_status = 2', -3)
       call writefile(body, g:this_obsession)
       let g:this_session = g:this_obsession
+      if exists('#User#Obsession')
+        try
+          let [save_mls, &modelines] = [&mls, 0]
+          doautocmd User Obsession
+        finally
+          let &mls = save_mls
+        endtry
+      endif
     catch
       unlet g:this_obsession
       let &l:readonly = &l:readonly

--- a/plugin/obsession.vim
+++ b/plugin/obsession.vim
@@ -70,9 +70,10 @@ function! s:persist() abort
   if exists('g:this_obsession')
     try
       set sessionoptions-=blank sessionoptions-=options sessionoptions+=tabpages
+      let tmp = g:this_obsession . '.obsession.' . getpid()
       exe s:doautocmd_user('ObsessionPre')
-      execute 'mksession! '.fnameescape(g:this_obsession)
-      let body = readfile(g:this_obsession)
+      execute 'mksession!' fnameescape(tmp)
+      let body = readfile(tmp)
       call insert(body, 'let g:this_session = v:this_session', -3)
       call insert(body, 'let g:this_obsession = v:this_session', -3)
       if type(get(g:, 'obsession_append')) == type([])
@@ -80,7 +81,8 @@ function! s:persist() abort
           call insert(body, line, -3)
         endfor
       endif
-      call writefile(body, g:this_obsession)
+      call writefile(body, tmp)
+      call rename(tmp, g:this_obsession)
       let g:this_session = g:this_obsession
       exe s:doautocmd_user('Obsession')
     catch /^Vim(mksession):E11:/

--- a/plugin/obsession.vim
+++ b/plugin/obsession.vim
@@ -74,6 +74,7 @@ function! s:persist() abort
   if exists('g:this_obsession')
     try
       set sessionoptions-=blank sessionoptions-=options sessionoptions+=tabpages
+      exe s:doautocmd_user('ObsessionPre')
       execute 'mksession! '.fnameescape(g:this_obsession)
       let body = readfile(g:this_obsession)
       call insert(body, 'let g:this_session = v:this_session', -3)

--- a/plugin/obsession.vim
+++ b/plugin/obsession.vim
@@ -86,6 +86,8 @@ function! s:persist() abort
       call writefile(body, g:this_obsession)
       let g:this_session = g:this_obsession
       exe s:doautocmd_user('Obsession')
+    catch /^Vim(mksession):E11:/
+      return ''
     catch
       unlet g:this_obsession
       let &l:readonly = &l:readonly
@@ -120,7 +122,7 @@ augroup obsession
   autocmd!
   autocmd VimLeavePre * exe s:persist()
   autocmd BufEnter *
-        \ if !get(g:, 'obsession_no_bufenter') && (&buftype !=# 'nofile' || len(expand('<afile>'))) |
+        \ if !get(g:, 'obsession_no_bufenter') |
         \   exe s:persist() |
         \ endif
   autocmd User Flags call Hoist('global', 'ObsessionStatus')

--- a/plugin/obsession.vim
+++ b/plugin/obsession.vim
@@ -120,7 +120,7 @@ augroup obsession
   autocmd!
   autocmd VimLeavePre * exe s:persist()
   autocmd BufEnter *
-        \ if !get(g:, 'obsession_no_bufenter') |
+        \ if !get(g:, 'obsession_no_bufenter') && (&buftype !=# 'nofile' || len(expand('<afile>'))) |
         \   exe s:persist() |
         \ endif
   autocmd User Flags call Hoist('global', 'ObsessionStatus')

--- a/plugin/obsession.vim
+++ b/plugin/obsession.vim
@@ -57,7 +57,7 @@ endfunction
 function! s:doautocmd_user(arg) abort
   if !exists('#User#' . a:arg)
     return ''
-  elseif v:version >= 704 && 0
+  elseif v:version >= 704
     return 'doautocmd <nomodeline> User ' . fnameescape(a:arg)
   else
     return 'try | let [save_mls, &mls] = [&mls, 0] | ' .

--- a/plugin/obsession.vim
+++ b/plugin/obsession.vim
@@ -67,8 +67,8 @@ function! s:persist() abort
       call insert(body, 'let g:this_session = v:this_session', -3)
       call insert(body, 'let g:this_obsession = v:this_session', -3)
       call insert(body, 'let g:this_obsession_status = 2', -3)
-      if exists('g:obsession_append')
-        for line in type(g:obsession_append) == type('') ? split(g:obsession_append, "\n") : g:obsession_append
+      if type(get(g:, 'obsession_append')) == type([])
+        for line in g:obsession_append
           call insert(body, line, -3)
         endfor
       endif

--- a/plugin/obsession.vim
+++ b/plugin/obsession.vim
@@ -1,6 +1,7 @@
 " obsession.vim - Continuously updated session files
 " Maintainer:   Tim Pope <http://tpo.pe/>
 " Version:      1.0
+" GetLatestVimScripts: 4472 1 :AutoInstall: obsession.vim
 
 if exists("g:loaded_obsession") || v:version < 700 || &cp
   finish
@@ -66,6 +67,11 @@ function! s:persist() abort
       call insert(body, 'let g:this_session = v:this_session', -3)
       call insert(body, 'let g:this_obsession = v:this_session', -3)
       call insert(body, 'let g:this_obsession_status = 2', -3)
+      if exists('g:obsession_append')
+        for line in type(g:obsession_append) == type('') ? split(g:obsession_append, "\n") : g:obsession_append
+          call insert(body, line, -3)
+        endfor
+      endif
       call writefile(body, g:this_obsession)
       let g:this_session = g:this_obsession
       if exists('#User#Obsession')
@@ -108,7 +114,11 @@ endfunction
 
 augroup obsession
   autocmd!
-  autocmd BufEnter,VimLeavePre * exe s:persist()
+  autocmd VimLeavePre * exe s:persist()
+  autocmd BufEnter *
+        \ if !get(g:, 'obsession_no_bufenter') |
+        \   exe s:persist() |
+        \ endif
   autocmd User Flags call Hoist('global', 'ObsessionStatus')
 augroup END
 

--- a/plugin/obsession.vim
+++ b/plugin/obsession.vim
@@ -3,7 +3,7 @@
 " Version:      1.0
 " GetLatestVimScripts: 4472 1 :AutoInstall: obsession.vim
 
-if exists("g:loaded_obsession") || v:version < 700 || &cp
+if exists("g:loaded_obsession") || v:version < 704 || &cp
   finish
 endif
 let g:loaded_obsession = 1
@@ -57,12 +57,8 @@ endfunction
 function! s:doautocmd_user(arg) abort
   if !exists('#User#' . a:arg)
     return ''
-  elseif v:version >= 704
-    return 'doautocmd <nomodeline> User ' . fnameescape(a:arg)
   else
-    return 'try | let [save_mls, &mls] = [&mls, 0] | ' .
-          \ 'doautocmd <nomodeline> User ' . fnameescape(a:arg) . ' | ' .
-          \ 'finally | let &mls = save_mls | endtry'
+    return 'doautocmd <nomodeline> User ' . fnameescape(a:arg)
   endif
 endfunction
 

--- a/plugin/obsession.vim
+++ b/plugin/obsession.vim
@@ -93,6 +93,7 @@ function! s:persist() abort
       return 'echoerr '.string(v:exception)
     finally
       let &sessionoptions = sessionoptions
+      call delete(tmp)
     endtry
   endif
   return ''


### PR DESCRIPTION
#@vphantom &
#@vim-plugin.yml

- [x] use vim with no plugin

- [x] nocompatible: Stops odd issues †.

- [x] number: Turn on line numbers.

- [x] cursorline: Highlight the current line.

- [x] expandtab: Convert tabs to spaces.

- [x] hlsearch: Highlight all search matches.

- [x] visualbell: Stop Vim from beeping at you when you make a mistake.

- [x] tabstop: Set tab size in spaces (this is for manual indenting).

- [x] shiftwidth: The number of spaces inserted for a tab (used for auto indenting).

- [x] syntax on: Enable basic syntax highlighting.


#NOTE: If you do decide to use plugins, then don’t forget to vim -c ":helptags ALL" -c ":q" to ensure you get all the relevant help information loaded.

- Now, there may be times where you want a minimal config but with some extra treats, I’ll typically have a ~/.vimrc-core file with the following configuration that gives me the above ‘basic’ configuration (with some other configuration which isn’t essential but also isn’t superfluous either) along with some core plugins I like to use):
- 

- [x] set nocompatible number autoread cursorline expandtab hlsearch visualbell tabstop=2 shiftwidth=2 clipboard+=unnamed wildmenu hidden noswapfile
syntax on
packadd cfilter

- [x] call plug#begin('~/.vim/plugged')
-Plug 'junegunn/fzf', { 'do': { -> fzf#install() } }
-Plug 'junegunn/fzf.vim' " <Tab> to select multiple results
-Plug 'mileszs/ack.vim'
-Plug 'unblevable/quick-scope'
-call plug#end()

- [x] map <leader>f :FZF<CR>
-map <leader>b :Buffers!<CR>
-map <leader>g :GFiles?<CR>
-map <leader>w :Windows<CR>
-map <leader>l :Lines<CR>
-map <leader>t :AgC<CR>

- [x] set wildignore+=*/.git/*,*/node_modules/*,*/.hg/*,*/.svn/*.,*/.DS_Store
set wildmode=list:longest,list:full

autocmd VimEnter * command! -nargs=* -bang AgC call fzf#vim#ag(<q-args>, '--path-to-ignore ~/.ignore --hidden --ignore "node_modules" --ignore-dir="vendor" --skip-vcs-ignores', <bang>0)

#let g:ackprg = 'ag --vimgrep --smart-case --path-to-ignore ~/.ignore --hidden --ignore-dir=node_modules --ignore-dir=vendor --skip-vcs-ignores'

#let g:ack_mappings = {
  \ "h": "<C-W><CR>:exe 'wincmd ' (&splitbelow ? 'J' : 'K')<CR><C-W>p<C-W>J<C-W>p",
  \ "v": "<C-W><CR>:exe 'wincmd ' (&splitright ? 'L' : 'H')<CR><C-W>p<C-W>J<C-W>p"}
  
silent! tnoremap <Esc> <C-\><C-n>